### PR TITLE
Fix typos in references to conversion script files

### DIFF
--- a/{{cookiecutter.repo_name}}/README.md
+++ b/{{cookiecutter.repo_name}}/README.md
@@ -16,7 +16,7 @@ We recommend that you install the package inside a [virtual environment](https:/
 ### Running a specific conversion
 Once you have installed the package with pip, you can run any of the conversion scripts in a notebook or a python file:
 
-https://github.com/catalystneuro/{{cookiecutter.repo_name}}//tree/main/src/{{cookiecutter.conversion_name}}/{{cookiecutter.conversion_name}}_conversion_script.py
+https://github.com/catalystneuro/{{cookiecutter.repo_name}}//tree/main/src/{{cookiecutter.conversion_name}}/{{cookiecutter.conversion_name}}_convert_session.py
 
 
 
@@ -54,7 +54,7 @@ pip install -r src/{{cookiecutter.repo_name_slug}}/{{cookiecutter.conversion_nam
 
 You can run a specific conversion with the following command:
 ```
-python src/{{cookiecutter.repo_name_slug}}/{{cookiecutter.conversion_name}}/{{cookiecutter.conversion_name}}_conversion_script.py
+python src/{{cookiecutter.repo_name_slug}}/{{cookiecutter.conversion_name}}/{{cookiecutter.conversion_name}}_convert_session.py
 ```
 
 ## Repository structure


### PR DESCRIPTION
Some bits of the default README refer to the conversion script file as `_conversion_script.py` instead of `_convert_session.py`, which can be a little misleading to anyone following along the steps exactly