### PR TITLE
Add default for subject id

### DIFF
--- a/{{cookiecutter.repo_name}}/src/{{cookiecutter.repo_name_slug}}/{{cookiecutter.conversion_name}}/{{cookiecutter.conversion_name}}_convert_session.py
+++ b/{{cookiecutter.repo_name}}/src/{{cookiecutter.repo_name_slug}}/{{cookiecutter.conversion_name}}/{{cookiecutter.conversion_name}}_convert_session.py
@@ -25,11 +25,7 @@ def session_to_nwb(data_dir_path: Union[str, Path], output_dir_path: Union[str, 
 
     # Add Recording
     source_data.update(dict(Recording=dict()))
-    conversion_options.update(dict(Recording=dict()))
-
-    # Add LFP
-    source_data.update(dict(LFP=dict()))
-    conversion_options.update(dict(LFP=dict()))
+    conversion_options.update(dict(Recording=dict(stub_test=stub_test)))
 
     # Add Sorting
     source_data.update(dict(Sorting=dict()))
@@ -53,6 +49,8 @@ def session_to_nwb(data_dir_path: Union[str, Path], output_dir_path: Union[str, 
     editable_metadata_path = Path(__file__).parent / "{{cookiecutter.conversion_name}}_metadata.yaml"
     editable_metadata = load_dict_from_file(editable_metadata_path)
     metadata = dict_deep_update(metadata, editable_metadata)
+
+    metadata["Subject"]["subject_id"] = "a_subject_id"  # Modify here or in the yaml file
 
     # Run conversion
     converter.run_conversion(metadata=metadata, nwbfile_path=nwbfile_path, conversion_options=conversion_options)


### PR DESCRIPTION
This is a required id so conversion does not run if not present. I am adding it on the script as it is usually metadata that changes per session (instead of in the yaml file I mean).

I also eliminated the reference to LFP which I removed in a previous PR.